### PR TITLE
bugfix in selecting files in target number table

### DIFF
--- a/ParameterOptimization.py
+++ b/ParameterOptimization.py
@@ -307,7 +307,7 @@ def main():
                 raise ValueError(
                     f'Video name {video_name.replace(".avi", "")} not found in target number of larvae dictionary.')
         # Filter dictionary to only include videos that are used for optimization
-        args.target_larvae_nr = {k: v for k, v in args.target_larvae_nr.items() if k in args.video_names}
+        args.target_larvae_nr = {k: v for k, v in args.target_larvae_nr.items() if f'{k}.avi' in args.video_names}
 
     print(f'Number of videos included in optimization: {len(args.video_names)}')
 


### PR DESCRIPTION
Argument `video_names` must list video files with the *.avi* extension, as properly documented [elsewhere](https://github.com/Lilly-May/larva-tagger-tune/blob/9810f3102c0a7e2fd1df3a8332a6744b4adfc630/ParameterOptimization.py#L55-L57). However, `target_larvae_nr` takes its content from a *.csv* file that lists video files by their name **without** the *.avi* extension, as examplified in the README file.

This PR makes file selection work, in the case files are listed using the `--video_names` commandline option.