### PR TITLE
--debug prints something

### DIFF
--- a/ParameterOptimization.py
+++ b/ParameterOptimization.py
@@ -205,7 +205,10 @@ def analyze_one_video(video_path, hyperparams, working_dir, date_time, video_nr,
             out, err = subprocess.DEVNULL, subprocess.DEVNULL
 
         # Run tracker for one video from working directory
-        subprocess.run(command, cwd=working_dir, stdout=out, stderr=err)
+        ret = subprocess.run(command, cwd=working_dir, stdout=out, stderr=err)
+
+        if args.debug and ret.stderr:
+            print(ret.stderr.decode('utf8'))
 
         # Each tracker has a different name for the file that contains the tracks, so we need to handle this
         if args.tracker == 'MWT':


### PR DESCRIPTION
This PR is not essential. It reflects a minor change that was useful to understand why larva-tagger-tune did not work at first, and could still be useful to understand how to properly use larva-tagger-tune.

The `--debug` commandline option did nothing. In particular it did not print any additional message. With this PR, passing `--debug` makes larva-tagger-tune print error messages from the tested tracker.