### PR TITLE
--output_dir commandline option

### DIFF
--- a/ParameterOptimization.py
+++ b/ParameterOptimization.py
@@ -191,7 +191,7 @@ def analyze_one_video(video_path, hyperparams, working_dir, output_dir, date_tim
     # Variable output_dir refers to the data/Optuna part.
     # If output_dir is defined, it should be an absolute path like the other directories.
     if output_dir is None:
-        f'./data/Optuna'
+        output_dir = f'./data/Optuna'
 
     # Get the basic command for the specified tracker
     if args.tracker == 'MWT':

--- a/ParameterOptimization.py
+++ b/ParameterOptimization.py
@@ -201,7 +201,7 @@ def analyze_one_video(video_path, hyperparams, working_dir, output_dir, date_tim
         command = ['julia', '--project=.', f'src/{args.tracker.lower()}-cli.jl', video_path,
                    f'{output_dir}/{video_id}/{date_time}']
     elif args.tracker == 'WF-NTP':
-        os.makedirs(f'{working_dir}/data/Optuna/{video_id}/{date_time}')
+        os.makedirs(f'{output_dir}/{video_id}/{date_time}')
         command = ['python', f'{working_dir}/src/wf_ntp_cli.py', video_path, f'{output_dir}/{video_id}/{date_time}']
     command.extend(hyperparams)
 


### PR DESCRIPTION
This PR introduces more changes than the others.

It introduces the `--output_dir` commandline option that makes larva-tagger-tune store the intermediate and result files in a designated directory, instead of a predefined location in the tested tracker's repository.

This has been critical because the main output directory is named after the current date and time, while larva-tagger-tune had to be run on multiple video files in parallel. Two larva-tagger-tune instances could potentially start within the same second and make their respective output directories using the exact same name and, as a consequence, an instance could overwrite the files generated by the other instance.

EDIT: note this PR should be non breaking. Not passing any location with the --output_dir option should result in the previous behavior without any change.